### PR TITLE
core: Switch datetime to avoid namespace conflicts

### DIFF
--- a/core/learn/apply_trained_classifier.m
+++ b/core/learn/apply_trained_classifier.m
@@ -138,7 +138,7 @@ for n=1:nIterations
   disp( sprintf('\t%.2f',cur_it.perf(1)) );
 
   % Book-keep the bountiful insight from this iteration
-  cur_it.created.datetime  = datetime(true);
+  cur_it.created.datetime  = pmvpa_datetime(true);
   cur_it.test_idx          = test_idx;
   cur_it.acts              = acts;
   cur_it.scratchpad        = scratchpad;

--- a/core/learn/cross_validation.m
+++ b/core/learn/cross_validation.m
@@ -287,7 +287,7 @@ for n=1:nIterations
   disp( sprintf('\t%.2f',cur_iteration.perf(p)) );
 
   % Book-keep the bountiful insight from this iteration
-  cur_iteration.created.datetime  = datetime(true);
+  cur_iteration.created.datetime  = pmvpa_datetime(true);
   cur_iteration.train_idx         = train_idx;
   cur_iteration.test_idx          = test_idx;
   cur_iteration.unused_idx        = unused_idx;

--- a/core/subj/duplicate_group.m
+++ b/core/subj/duplicate_group.m
@@ -47,7 +47,7 @@ for o=1:nObjs
   
   % store history of how this came to be
   created = [];
-  created.datetime = datetime(true);
+  created.datetime = pmvpa_datetime(true);
   created.dbstack = dbstack;
   created.function = mfilename;
   created.old_groupname = old_groupname;

--- a/core/subj/duplicate_object.m
+++ b/core/subj/duplicate_object.m
@@ -75,7 +75,7 @@ whole_obj.header.history = {};
 % structure because of a weird matlab syntax thing to do with
 % creating empty structs. there should still only be one 'created'
 % structure
-whole_obj.created.datetime = datetime(true);
+whole_obj.created.datetime = pmvpa_datetime(true);
 whole_obj.last_modified = [];
 if ~args.transfer_group_name
   whole_obj.group_name = '';

--- a/core/subj/init_object.m
+++ b/core/subj/init_object.m
@@ -79,7 +79,7 @@ obj.matsize = size([]);
 obj.group_name = '';
 obj.derived_from = '';
 obj.header.description = '';
-obj.created.datetime = datetime(true);
+obj.created.datetime = pmvpa_datetime(true);
 obj.created.dbstack = dbstack;
 
 % Deal with particular fields that are specific to different types

--- a/core/subj/init_subj.m
+++ b/core/subj/init_subj.m
@@ -37,7 +37,7 @@ function [subj] = init_subj(exp_name,id,varargin)
 
 
 version = 3;
-created = datetime(true);
+created = pmvpa_datetime(true);
 
 defaults.subdir = sprintf('%s_%s_%s',exp_name,id,created);
 defaults.username = '';

--- a/core/subj/move_pattern_to_hd.m
+++ b/core/subj/move_pattern_to_hd.m
@@ -61,7 +61,7 @@ if exist_objfield(subj,'pattern',patname,'movehd')
   return
 end
 
-dt = datetime(true);
+dt = pmvpa_datetime(true);
 
 % Won't overwrite an existing file of same name
 pathfilename = sprintf('%s/%s_%s',args.subdir,patname,dt);

--- a/core/subj/set_mat.m
+++ b/core/subj/set_mat.m
@@ -77,7 +77,7 @@ if exist_objfield(subj,objtype,objname,'movehd')
   mat = newmat;  
   save(movehd.pathfilename,'mat');
   clear mat
-  subj = set_objsubfield(subj,objtype,objname,'movehd','last_saved',datetime(true),'ignore_absence',true);
+  subj = set_objsubfield(subj,objtype,objname,'movehd','last_saved',pmvpa_datetime(true),'ignore_absence',true);
  
 % Otherwise, get the cell array. Mess with the appropriate cell in
 % it. Set it back into the subj structure
@@ -98,7 +98,7 @@ subj = set_objfield(subj,objtype,objname,'matsize',size(newmat));
 % Record that we modified this. Could be useful. Don't ask me when
 % or why. Mine is not the place to know these things. The brain
 % moves in mysterious ways
-subj = set_objfield(subj,objtype,objname,'last_modified',datetime(true),'ignore_absence',true);
+subj = set_objfield(subj,objtype,objname,'last_modified',pmvpa_datetime(true),'ignore_absence',true);
 
 % Update type-specific stuff
 switch(objtype)

--- a/core/util/bundle.m
+++ b/core/util/bundle.m
@@ -24,7 +24,7 @@ function [ history ] = bundle(varargin)
 %     You can also mix and match variables and expressions, regardless
 %     of the type, as much as you like.  For example:
 %     
-%     b = bundle(datetime(true), 'timestamp', x, y, @sin, 'sin')
+%     b = bundle(pmvpa_datetime(true), 'timestamp', x, y, @sin, 'sin')
 %
 %     will create a structure b with field 'timestamp' set to the
 %     current date and time with seconds, fields 'x' and 'y' set to


### PR DESCRIPTION
Switch to the in-tree pmvpa_datetime since Matlab (since 2014) has its
own datetime function included.

Signed-off-by: Sol Jerome <solj@utdallas.edu>